### PR TITLE
Check if closest LI-element is within editor.

### DIFF
--- a/table.js
+++ b/table.js
@@ -207,8 +207,7 @@
 				this.buffer.set();
 
 				var current = this.selection.current();
-				var $closestLi = $(current).closest('li');
-				if ($closestLi.length !== 0 && this.$editor.has($closestLi).length !== 0)
+				if ($(current).closest('li', this.core.editor().get(0)).length !== 0)
 				{
 					$(current).closest('ul, ol').first().after(html);
 				}

--- a/table.js
+++ b/table.js
@@ -207,7 +207,8 @@
 				this.buffer.set();
 
 				var current = this.selection.current();
-				if ($(current).closest('li').length !== 0)
+				var $closestLi = $(current).closest('li');
+				if ($closestLi.length !== 0 && this.$editor.has($closestLi).length !== 0)
 				{
 					$(current).closest('ul, ol').first().after(html);
 				}


### PR DESCRIPTION
We have multiple redactor-editors on one page, and some (or all) of them are placed within a LI tag.
Whenever the user tries to add a table, the table is placed after the closing LI tag, and thus outside the editor.

The change makes the plugin check if the closest LI tag is within the editor.
If so, it places the table after it. If not, it places the table where the cursor is.
